### PR TITLE
chore: rename future base exception

### DIFF
--- a/.speakeasy/gen.yaml
+++ b/.speakeasy/gen.yaml
@@ -25,7 +25,7 @@ csharp:
   version: 0.2.8
   additionalDependencies: []
   author: stackone
-  baseErrorName: StackOneError
+  baseErrorName: BaseException
   clientServerStatusCodesAsErrors: true
   defaultErrorName: APIException
   disableNamespacePascalCasingApr2024: true


### PR DESCRIPTION
In an upcoming release, all SDK exceptions will inherit from a _base_ exception to ease error handling. Given that the _default_ exception is currently named `APIException`, this PR aims at improving naming consistency by editing the `baseErrorName` configuration parameter. Note this configuration change is a no-op for now and will only have effect once the new Error handling feature is released.

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Rename the future SDK base exception to BaseException in .speakeasy/gen.yaml to keep names consistent and prep for the new error handling. No runtime change yet; it takes effect when the feature ships and APIException remains the default error.

<!-- End of auto-generated description by cubic. -->

