### PR TITLE
chore: remove screening OAS

### DIFF
--- a/.speakeasy/workflow.yaml
+++ b/.speakeasy/workflow.yaml
@@ -12,7 +12,6 @@ sources:
             - location: https://api.eu1.stackone.com/oas/lms.json
             - location: https://api.eu1.stackone.com/oas/ticketing.json
             - location: https://api.eu1.stackone.com/oas/documents.json
-            - location: https://api.eu1.stackone.com/oas/screening.json
             - location: https://api.eu1.stackone.com/oas/messaging.json
             - location: https://api.eu1.stackone.com/oas/accounting.json
         overlays:


### PR DESCRIPTION
The Screening OAS is not being used yet in this SDK and it was removed for now.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Removed the Screening OAS from .speakeasy/workflow.yaml because it isn’t used in the SDK yet, reducing unnecessary processing. No SDK behavior changes.

<!-- End of auto-generated description by cubic. -->

