### PR TITLE
Pinning GitHub actions

### DIFF
--- a/.github/workflows/sdk_generation.yaml
+++ b/.github/workflows/sdk_generation.yaml
@@ -23,7 +23,7 @@ permissions:
       - unlabeled
 jobs:
   generate:
-    uses: speakeasy-api/sdk-generation-action/.github/workflows/workflow-executor.yaml@v15
+    uses: speakeasy-api/sdk-generation-action/.github/workflows/workflow-executor.yaml@3fdab59e74dda7831d7401f7aa1bb55d706913d7 # v15
     with:
       force: ${{ github.event.inputs.force }}
       mode: pr

--- a/.github/workflows/sdk_publish.yaml
+++ b/.github/workflows/sdk_publish.yaml
@@ -14,7 +14,7 @@ permissions:
   workflow_dispatch: {}
 jobs:
   publish:
-    uses: speakeasy-api/sdk-generation-action/.github/workflows/sdk-publish.yaml@v15
+    uses: speakeasy-api/sdk-generation-action/.github/workflows/sdk-publish.yaml@3fdab59e74dda7831d7401f7aa1bb55d706913d7 # v15
     with:
       target: stack-one
     secrets:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Pinned GitHub Actions in sdk_generation and sdk_publish workflows to a specific commit SHA to enforce org-wide pinning and improve supply-chain security. Aligns with ENG-11298.

- **Dependencies**
  - Pin speakeasy-api/sdk-generation-action workflow-executor and sdk-publish to commit 3fdab59e74dda7831d7401f7aa1bb55d706913d7 (v15).

<sup>Written for commit e75c3a9133597aa3582f9a4f176f0e89d4e4b3cd. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

